### PR TITLE
[개선] 게시물 Type을 Int 대신 enum type으로 변경

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,122 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="1.8" />
@@ -15,7 +15,6 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/data/entities/BoardTypeState.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/data/entities/BoardTypeState.kt
@@ -1,0 +1,10 @@
+package com.yeonkyu.blindcommunity2.data.entities
+
+enum class BoardTypeState(val type: Int) {
+    Free(1),
+    Info(2),
+    Employ(3),
+    None(0);
+
+    fun getBoardType() = type
+}

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/data/entities/BoardTypeState.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/data/entities/BoardTypeState.kt
@@ -4,7 +4,5 @@ enum class BoardTypeState(val type: Int) {
     Free(1),
     Info(2),
     Employ(3),
-    None(0);
-
-    fun getBoardType() = type
+    None(0)
 }

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/data/repository/BoardPagingSource.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/data/repository/BoardPagingSource.kt
@@ -5,15 +5,16 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.yeonkyu.blindcommunity2.data.api.BoardService
 import com.yeonkyu.blindcommunity2.data.entities.BoardInfo
+import com.yeonkyu.blindcommunity2.data.entities.BoardTypeState
 
-class BoardPagingSource(private val boardType: Int, private val boardService: BoardService) : PagingSource<Int, BoardInfo>() {
+class BoardPagingSource(private val boardType: BoardTypeState, private val boardService: BoardService) : PagingSource<Int, BoardInfo>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, BoardInfo> {
         return try{
             val nextPage = params.key ?: 0
             val response = when(boardType){
-                1 -> boardService.getFreeBoard(nextPage).body()
-                2 -> boardService.getInfoBoard(nextPage).body()
-                3 -> boardService.getEmployeeBoard(nextPage).body()
+                BoardTypeState.Free -> boardService.getFreeBoard(nextPage).body()
+                BoardTypeState.Info -> boardService.getInfoBoard(nextPage).body()
+                BoardTypeState.Employ -> boardService.getEmployeeBoard(nextPage).body()
                 else -> null
             }
             val data = response?.result as List<BoardInfo>

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardActivity.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardActivity.kt
@@ -65,15 +65,15 @@ class BoardActivity : AppCompatActivity(){
         when(intent.getStringExtra("type")){
             "free" -> {
                 binding.boardTv.text = "자유 게시판"
-                boardViewModel.setBoardType(BoardTypeState.Free)
+                boardViewModel.boardType = BoardTypeState.Free
             }
             "info" -> {
                 binding.boardTv.text = "정보 게시판"
-                boardViewModel.setBoardType(BoardTypeState.Info)
+                boardViewModel.boardType = BoardTypeState.Info
             }
             "employee" -> {
                 binding.boardTv.text = "취업 게시판"
-                boardViewModel.setBoardType(BoardTypeState.Employ)
+                boardViewModel.boardType = BoardTypeState.Employ
             }
         }
 
@@ -109,7 +109,7 @@ class BoardActivity : AppCompatActivity(){
     private fun moveToPostActivity(postId: String){
         val intent = Intent(this, PostActivity::class.java)
         intent.putExtra("postId", postId)
-        intent.putExtra("postType", boardViewModel.getBoardType())
+        intent.putExtra("postType", boardViewModel.boardType)
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardActivity.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardActivity.kt
@@ -11,9 +11,8 @@ import androidx.lifecycle.observe
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.yeonkyu.blindcommunity2.R
-import com.yeonkyu.blindcommunity2.data.entities.BoardInfo
+import com.yeonkyu.blindcommunity2.data.entities.BoardTypeState
 import com.yeonkyu.blindcommunity2.databinding.ActivityBoardBinding
-import com.yeonkyu.blindcommunity2.generated.callback.OnClickListener
 import com.yeonkyu.blindcommunity2.ui.post.PostActivity
 import com.yeonkyu.blindcommunity2.ui.write.WriteActivity
 import kotlinx.coroutines.flow.collectLatest
@@ -66,15 +65,15 @@ class BoardActivity : AppCompatActivity(){
         when(intent.getStringExtra("type")){
             "free" -> {
                 binding.boardTv.text = "자유 게시판"
-                boardViewModel.setBoardType(1)
+                boardViewModel.setBoardType(BoardTypeState.Free)
             }
             "info" -> {
                 binding.boardTv.text = "정보 게시판"
-                boardViewModel.setBoardType(2)
+                boardViewModel.setBoardType(BoardTypeState.Info)
             }
             "employee" -> {
                 binding.boardTv.text = "취업 게시판"
-                boardViewModel.setBoardType(3)
+                boardViewModel.setBoardType(BoardTypeState.Employ)
             }
         }
 
@@ -107,10 +106,10 @@ class BoardActivity : AppCompatActivity(){
         }
     }
 
-    fun moveToPostActivity(postId: String){
+    private fun moveToPostActivity(postId: String){
         val intent = Intent(this, PostActivity::class.java)
-        intent.putExtra("postId",postId)
-        intent.putExtra("postType",boardViewModel.getBoardType())
+        intent.putExtra("postId", postId)
+        intent.putExtra("postType", boardViewModel.getBoardType())
         startActivity(intent)
     }
 

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardViewModel.kt
@@ -16,7 +16,7 @@ class BoardViewModel(private val repository: BoardRepository) : ViewModel(){
 
     var hasBeenInit = false
 
-    private var boardType = BoardTypeState.None
+    var boardType = BoardTypeState.None
 
     private val _writePostEvent = MutableLiveData<Event<String>>()
     val writePostEvent : LiveData<Event<String>>
@@ -25,14 +25,6 @@ class BoardViewModel(private val repository: BoardRepository) : ViewModel(){
     val boardFlow = Pager(PagingConfig(pageSize = 20)) {
         BoardPagingSource(boardType, repository.boardService)
     }.flow.cachedIn(viewModelScope)
-
-    fun setBoardType(type: BoardTypeState){
-        boardType = type
-    }
-
-    fun getBoardType(): Int{
-        return boardType.type
-    }
 
     fun writePost(){
         when(boardType){

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardViewModel.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/ui/board/BoardViewModel.kt
@@ -7,15 +7,16 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
+import com.yeonkyu.blindcommunity2.data.entities.BoardTypeState
 import com.yeonkyu.blindcommunity2.data.repository.BoardPagingSource
 import com.yeonkyu.blindcommunity2.data.repository.BoardRepository
 import com.yeonkyu.blindcommunity2.utils.Event
 
-class BoardViewModel(private val repository:BoardRepository) : ViewModel(){
+class BoardViewModel(private val repository: BoardRepository) : ViewModel(){
 
     var hasBeenInit = false
 
-    private var boardType = 0 //1:자유게시판 2:정보게시판 3:취업게시판
+    private var boardType = BoardTypeState.None
 
     private val _writePostEvent = MutableLiveData<Event<String>>()
     val writePostEvent : LiveData<Event<String>>
@@ -25,19 +26,21 @@ class BoardViewModel(private val repository:BoardRepository) : ViewModel(){
         BoardPagingSource(boardType, repository.boardService)
     }.flow.cachedIn(viewModelScope)
 
-    fun setBoardType(type:Int){
+    fun setBoardType(type: BoardTypeState){
         boardType = type
     }
 
     fun getBoardType(): Int{
-        return boardType
+        return boardType.type
     }
 
     fun writePost(){
         when(boardType){
-            1 -> _writePostEvent.postValue(Event("자유 게시판"))
-            2 -> _writePostEvent.postValue(Event("정보 게시판"))
-            3 -> _writePostEvent.postValue(Event("취업 게시판"))
+            BoardTypeState.Free -> _writePostEvent.postValue(Event("자유 게시판"))
+            BoardTypeState.Info -> _writePostEvent.postValue(Event("정보 게시판"))
+            BoardTypeState.Employ -> _writePostEvent.postValue(Event("취업 게시판"))
         }
     }
+
+
 }

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/ui/post/PostActivity.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/ui/post/PostActivity.kt
@@ -7,6 +7,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.yeonkyu.blindcommunity2.R
+import com.yeonkyu.blindcommunity2.data.entities.BoardTypeState
 import com.yeonkyu.blindcommunity2.data.entities.CommentInfo
 import com.yeonkyu.blindcommunity2.databinding.ActivityPostBinding
 import com.yeonkyu.blindcommunity2.ui.BaseActivity
@@ -24,11 +25,11 @@ class PostActivity: BaseActivity(), DialogListener {
         super.onCreate(savedInstanceState)
 
         val postId = intent.getStringExtra("postId")
-        val postType = intent.getIntExtra("postType",0)
-        Log.e("BC_CHECK","postID : $postId")
-        postViewModel.postId.value = postId
+        val postType = intent.getSerializableExtra("postType") as BoardTypeState
+        Log.e("BC_CHECK","postID : $postId, postType : $postType")
 
-        postViewModel.type = postType
+        postViewModel.postId.value = postId
+        postViewModel.boardType = postType
 
         setupView()
         setupViewModel()

--- a/app/src/main/java/com/yeonkyu/blindcommunity2/ui/post/PostViewModel.kt
+++ b/app/src/main/java/com/yeonkyu/blindcommunity2/ui/post/PostViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yeonkyu.blindcommunity2.ApplicationClass
 import com.yeonkyu.blindcommunity2.data.entities.BoardInfo
+import com.yeonkyu.blindcommunity2.data.entities.BoardTypeState
 import com.yeonkyu.blindcommunity2.data.entities.CommentInfo
 import com.yeonkyu.blindcommunity2.data.repository.PostRepository
 import com.yeonkyu.blindcommunity2.data.room_persistence.Favorites
@@ -21,7 +22,7 @@ import kotlin.collections.ArrayList
 class PostViewModel(private val repository: PostRepository, private val db: FavoritesDao) : ViewModel() {
 
     var hasBeenInit = false
-    var type: Int? = null//1: free, 2: info, 3: employ
+    var boardType = BoardTypeState.None
     val postId = MutableLiveData<String>()
 
     val isStared = MutableLiveData<Boolean>()
@@ -69,10 +70,10 @@ class PostViewModel(private val repository: PostRepository, private val db: Favo
             try{
                 isLoading.postValue(true)
                 postId.value?.let {
-                    val response = when(type){
-                        1 -> repository.getFreePost(it)
-                        2 -> repository.getInfoPost(it)
-                        3 -> repository.getEmployPost(it)
+                    val response = when(boardType){
+                        BoardTypeState.Free -> repository.getFreePost(it)
+                        BoardTypeState.Info -> repository.getInfoPost(it)
+                        BoardTypeState.Employ -> repository.getEmployPost(it)
                         else -> null
                     }
                     response?.let {
@@ -121,7 +122,7 @@ class PostViewModel(private val repository: PostRepository, private val db: Favo
 
     fun insertOrDeleteStar(){
         viewModelScope.launch(Dispatchers.Default) {
-            val favorite = Favorites(postId.value!!,nickname.value!!,title.value!!,type!!.toString())
+            val favorite = Favorites(postId.value!!,nickname.value!!,title.value!!,boardType.type.toString())
             if(isStared.value == true){
                 db.deletePost(favorite)
                 isStared.postValue(false)
@@ -209,7 +210,7 @@ class PostViewModel(private val repository: PostRepository, private val db: Favo
                     if(isWriterResponse.isSuccess){
                         val postInfo = BoardInfo(
                                 postId = postId.value!!,
-                                type = type!!.toString(),
+                                type = boardType.type!!.toString(),
                                 nickname = null,
                                 title = null
                         )


### PR DESCRIPTION
### 배경
- 기존의 Int로 게시물 분류를 하던 방식은 아래의 위험이 있음
  - 정해진 숫자(1~3) 이 아닌 다른 데이터를 실수로 넣을 경우 문제를 발견하지 못할 가능성이 있음
  - 숫자로 상태를 관리하는 것은 그 숫자가 어떤 상태를 가리키는지 직관적이지 못함. 즉, 가독성이 떨어졌음

### 변경 사항
- enum class BoardTypeState 를 생성
- BoardActivity, BoardViewModel, PostActivity, PostViewModel, BoardPagingSouce 에서 사용되는 boardType: Int 변수 삭제
- boardTypeState를 이용하여 대체
- 서버에 통신할 땐 숫자로 게시물 종류를 알려주었기 때문에 통신할 땐 숫자로 다시 환산하기 위해 BoardTypeState에 Int형 프로퍼티를 가지게 하였다.